### PR TITLE
Ignore socket.error exceptions when sending/recving during peer detection

### DIFF
--- a/bonding.py
+++ b/bonding.py
@@ -281,10 +281,13 @@ def peers(quiet = True):
       # Try sending and receiving 3 times to give us better chances of catching the send
       # Generally we always catch on the first time
       for i in xrange(0, 3):
-        s1.sendall('%s%s%s%s' % (dstMac, srcMac, frameType, payload))
+        try:
+          s1.sendall('%s%s%s%s' % (dstMac, srcMac, frameType, payload))
+        except (socket.timeout, socket.error):
+          continue
         try:
           data = s2.recv(60)
-        except socket.timeout:
+        except (socket.timeout, socket.error):
           continue
         recvFrameType = data[12:14]
         recvPayload = data[14:]


### PR DESCRIPTION
I found that the peer detection was aborting with a socket.error exception on servers with unconnected 10G interfaces.  I suspect this may be specific to the ixgbe driver.

In any case, I think it makes sense to just ignore these exceptions and continue looking for possible peers.
