### PR TITLE
Corrected the set_iface_flag function to work for interfaces named with more than 4 chars (e.g., eth10, eth11 ...).

### DIFF
--- a/bonding.py
+++ b/bonding.py
@@ -142,7 +142,7 @@ def set_iface_flag(ifname, flag, flags = None):
     ifreq = fcntl.ioctl(s.fileno(), SIOCGIFFLAGS, struct.pack('256s', ifname[:15]))
     (flags,) = struct.unpack('16xH', ifreq[:18])
   flags |= flag
-  ifreq = struct.pack('4s12xH', ifname, flags)
+  ifreq = struct.pack('16sH', ifname, flags)
   fcntl.ioctl(s.fileno(), SIOCSIFFLAGS, ifreq)
   s.close()
   return flags


### PR DESCRIPTION
Hi,

Firstly thank you very much for this great script. It removes the burden of finding the bonding pairs if you have a large number of interfaces. 

Unfortunately, bonding.py didn't work for a system with more than 10 interfaces.

The problem is:

set_iface_flag function function does not work for interfaces named with more than 4 chars (e.g., eth10, eth11 ...)

Because, ifname is assumed to have 4 chars on line 145:
ifreq = struct.pack('4s12xH', ifname, flags)

Since, set_iface_flag is used in the peers detection to enable the DOWN interfaces, It can not enable interfaces eth10, eth11, etc. and the peers detection does not work as expected.

I am not sure whether we have to hard-code the interface name length but I have made it to work for me by changing the line to 

ifreq = struct.pack('16sH', ifname, flags)